### PR TITLE
Fix Arbitary Code Execution

### DIFF
--- a/lib/configUtil.js
+++ b/lib/configUtil.js
@@ -14,40 +14,40 @@ module.exports = {
     // List of Chromium Command Line Switches
     // https://peter.sh/experiments/chromium-command-line-switches/
     var proxyOption = pacFileURL
-      ? '--proxy-pac-url="' + pacFileURL + '"'
-      : '--proxy-server="' + proxyURL + '"';
+      ? '--proxy-pac-url=' + pacFileURL
+      : '--proxy-server=' + proxyURL;
 
     bypassList = bypassList === undefined ? '<local>' : bypassList;
 
     return [
-      // '--proxy-pac-url="' + proxy + '"',
-      // '--proxy-server="' + proxy + '"',
+      // '--proxy-pac-url=' + proxy,
+      // '--proxy-server=' + proxy,
       proxyOption,
-      '--proxy-bypass-list="' + bypassList + '"',
-      '--user-data-dir="' + dataDir + '/chrome-cache' + '"',
+      '--proxy-bypass-list=' + bypassList,
+      '--user-data-dir=' + dataDir + '/chrome-cache',
       '--lang=local',
       url
-    ].join(' ');
+    ];
   },
 
   opera: function (dataDir, url, operaPath, proxyURL, pacFileURL, bypassList) {
     var proxyOption = pacFileURL
-      ? '--proxy-pac-url="' + pacFileURL + '"'
-      : '--proxy-server="' + proxyURL + '"';
+      ? '--proxy-pac-url=' + pacFileURL
+      : '--proxy-server=' + proxyURL;
 
     bypassList = bypassList === undefined ? '<local>' : bypassList;
 
     return [
       proxyOption,
-      '--proxy-bypass-list="' + bypassList + '"',
-      '--user-data-dir="' + dataDir + '/opera-cache' + '"',
+      '--proxy-bypass-list=' + bypassList,
+      '--user-data-dir=' + dataDir + '/opera-cache',
       '--lang=local',
       url
-    ].join(' ');
+    ];
   },
 
   safari: function (dataDir, url, safariPath, proxy) {
-    return '';
+    return [];
   },
 
   firefox: function (dataDir, url, firefoxPath, proxyURL, pacFileURL, bypassList) {
@@ -86,7 +86,7 @@ module.exports = {
       }
 
       // https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options
-      childProcess.execSync(firefoxPath + ' -CreateProfile "firefox_hii_pref ' + dir + '"');
+      childProcess.execFileSync(firefoxPath,  ['-CreateProfile', 'firefox_hii_pref' + dir]);
       fs.writeFileSync(prefsPath, prefs.join('\n'));
     }
 
@@ -94,6 +94,6 @@ module.exports = {
       '-P firefox_hii_pref',
       '-no-remote',
       url
-    ].join(' ');
+    ]
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,8 +71,7 @@ module.exports = {
         var commandOptions = configUtil[browser](dataDir, url, browserPath, proxyURL, pacFileURL, bypassList);
 
         return new Promise(function (resolve, reject) {
-          var cmdStr = browserPath + ' ' + commandOptions;
-          childProcess.exec(cmdStr, {maxBuffer: 50000 * 1024}, function (err) {
+          childProcess.execFile(browserPath,  commandOptions, {maxBuffer: 50000 * 1024}, function (err) {
             if (err) {
               reject(err);
             } else {
@@ -108,8 +107,9 @@ module.exports = {
       try {
         switch (platform) {
           case 'darwin':
-            cmd = 'mdfind "kMDItemCFBundleIdentifier==' + info.darwin + '" | head -1';
-            result = childProcess.execSync(cmd).toString().trim();
+            cmd = 'mdfind'
+            cmdArgs = ['kMDItemCFBundleIdentifier==' + info.darwin];
+            result = childProcess.execFileSync(cmd, cmdArgs).toString().split(/\r?\n/)[0].trim();
             result += '/Contents/MacOS/' + info.appName;
             result = result.replace(/\s/g, '\\ ');
             break;
@@ -119,14 +119,15 @@ module.exports = {
             // HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe
             // reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe" /v Path
 
-            cmd = 'reg query "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\' + info.win32 + '" /ve';
+            cmd = 'reg'
+            cmdArgs = ['query', 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\' + info.win32, '/ve'];
             // result:
             /*
             HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\firefox.exe
             (默认)    REG_SZ    C:\Program Files\Mozilla Firefox\firefox.exe
             */
 
-            result = childProcess.execSync(cmd).toString().trim();
+            result = childProcess.execFileSync(cmd, cmdArgs).toString().trim();
             result = result.split('\n').pop().split(/\s+REG_SZ\s+/).pop();
             result = result.replace(/^"|"$/g, '');
             break;


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-op-browser/

### ⚙️ Description *

open-browser was vulnerable against arbitrary command injection cause some user supplied inputs were taken and formatted inside the exec() function without prior validation.
After update Arbitary Code Execution is avoided by using execFile instead of exec

### 💻 Technical Description *

Arbitary Code Execution is avoided by using execFile()/execFileSync() instead of exec()/execSync() and passing arguments via parameters instead of composing string

Vulnerable functions found and fixed in:

- [x] lib/index.js
- [x] lib/configUtils

### 🐛 Proof of Concept (PoC) *

Install the package and run the below code:

```javascript
var root = require("./");
root.open('chrome','& touch Song','','');
```

It will create a file named Song in the working directory.
![openBrowserPOC](https://user-images.githubusercontent.com/7505980/92406500-d8757a00-f140-11ea-97a9-92db0b39641f.png)


### 🔥 Proof of Fix (PoF) *

After fix no file is created

![openBrowserOK](https://user-images.githubusercontent.com/7505980/92407000-1aeb8680-f142-11ea-9124-eb74fe8e08fe.png)


### 👍 User Acceptance Testing (UAT)

Commands can be executed normally
